### PR TITLE
Fix a bug that produces incorrect file paths for all filename txts

### DIFF
--- a/costar_hyper/costar_block_stacking_split_dataset.py
+++ b/costar_hyper/costar_block_stacking_split_dataset.py
@@ -61,7 +61,7 @@ def _parse_args():
                             os.path.expanduser("~"),
                             '.keras/datasets/costar_block_stacking_dataset_v0.4/'),
                         help='path to dataset folder containing many files')
-    parser.add_argument("--dataset_path", type=str, default='~/.keras/dataset/',
+    parser.add_argument("--dataset_path", type=str, default='~/.keras/datasets/',
                         help='The folder that is expected stores the dataset. '
                              'Filenames in the output file will reference this path.')
     parser.add_argument("--dataset_name", type=str,


### PR DESCRIPTION
Found a bug that caused file paths to be wrong in all filename txts on the Archive right now.

Suggest fix:

1. Rerun ```python costar_block_stacking_split_dataset.py | grep "Example .h5f path in the txt file"``` and confirm that the path shown is correct. 
2. Then run ```python costar_block_stacking_split_dataset.py --write```
3. Use the following command to confirm that only the new v0.4 files are uploaded: ```python costar_block_stacking_internet_archive_upload --include_ext '.txt' ```
4. And upload them for real: ```python costar_block_stacking_internet_archive_upload --include_ext '.txt' --upload```